### PR TITLE
[REAUTH ENFORCER] fix for 'uninitialized constant ReauthEnforcer'

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -2,7 +2,7 @@ class SessionsController < Devise::SessionsController
   skip_before_action :handle_two_step_verification
 
   def destroy
-    ReauthEnforcer.perform_on(current_user) if current_user
+    ::ReauthEnforcer.perform_on(current_user) if current_user
     super
   end
 

--- a/app/controllers/suspensions_controller.rb
+++ b/app/controllers/suspensions_controller.rb
@@ -14,7 +14,7 @@ class SuspensionsController < ApplicationController
     if succeeded
       EventLog.record_event(@user, action, initiator: current_user)
       PermissionUpdater.perform_on(@user)
-      ReauthEnforcer.perform_on(@user)
+      ::ReauthEnforcer.perform_on(@user)
 
       flash[:notice] = "#{@user.email} is now #{@user.suspended? ? 'suspended' : 'active'}."
 

--- a/lib/inactive_users_suspender.rb
+++ b/lib/inactive_users_suspender.rb
@@ -6,7 +6,7 @@ class InactiveUsersSuspender
       user.save(validate: false)
 
       PermissionUpdater.perform_on(user)
-      ReauthEnforcer.perform_on(user)
+      ::ReauthEnforcer.perform_on(user)
 
       EventLog.record_event(user, EventLog::ACCOUNT_AUTOSUSPENDED)
       UserMailer.suspension_notification(user).deliver_now


### PR DESCRIPTION
[SENTRY ISSUE](https://sentry.io/bit-zesty-client-apps/management/issues/483006340)